### PR TITLE
Badge Count Issue - When App becomes active - resolved

### DIFF
--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -87,7 +87,7 @@ static char launchNotificationKey;
     NSLog(@"active");
     
     //zero badge
-    application.applicationIconBadgeNumber = 0;
+    //application.applicationIconBadgeNumber = 0;
 
     if (self.launchNotification) {
         PushPlugin *pushHandler = [self getCommandInstance:@"PushPlugin"];


### PR DESCRIPTION
Removed the default Badge reset code, when the app "applicationDidBecomeActive" active method is called.
